### PR TITLE
Enable DPI awerness

### DIFF
--- a/BF1SimpleFPSTweaks/ApplicationEvents.vb
+++ b/BF1SimpleFPSTweaks/ApplicationEvents.vb
@@ -1,0 +1,24 @@
+﻿Imports Microsoft.VisualBasic.ApplicationServices
+
+Namespace My
+    ' The following events are available for MyApplication:
+    ' Startup: Raised when the application starts, before the startup form is created.
+    ' Shutdown: Raised after all application forms are closed.  This event is not raised if the application terminates abnormally.
+    ' UnhandledException: Raised if the application encounters an unhandled exception.
+    ' StartupNextInstance: Raised when launching a single-instance application and the application is already active. 
+    ' NetworkAvailabilityChanged: Raised when the network connection is connected or disconnected.
+    Partial Friend Class MyApplication
+        ' Declare win32 native function to enable DPI awerness
+        Private Declare Function SetProcessDPIAware Lib "user32.dll" () As Boolean
+
+        Private Sub MyApplication_Startup(
+            ByVal sender As Object,
+            ByVal e As StartupEventArgs
+        ) Handles Me.Startup
+            ' If Windows Vista or higher enable DPI Awareness
+            If Environment.OSVersion.Version.Major >= 6 Then
+                SetProcessDPIAware()
+            End If
+        End Sub
+    End Class
+End Namespace

--- a/BF1SimpleFPSTweaks/BF1SimpleFPSTweaks.vbproj
+++ b/BF1SimpleFPSTweaks/BF1SimpleFPSTweaks.vbproj
@@ -90,6 +90,7 @@
     <Import Include="System.Threading.Tasks" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApplicationEvents.vb" />
     <Compile Include="Editor.vb" />
     <Compile Include="Main.vb">
       <SubType>Form</SubType>


### PR DESCRIPTION
By default Windows forms don't scale well on Windows configurations with custom DPI settings. 
As a result forms and controls look very blurry on with those DPI configurations enabled.

**Comparison on Windows 10 with 125 dpi**
(Note that the screenshots don't have their original quality)

**Before:**
![no-dpi-awerness](https://cloud.githubusercontent.com/assets/6338315/21962056/56a352b6-db1b-11e6-85af-eb9e56e9aac5.PNG)

**After:**
![with-dpi-awerness](https://cloud.githubusercontent.com/assets/6338315/21962058/5ac69434-db1b-11e6-8b06-4f481f131b4e.PNG)

**Commit message:**
Enable Windows Forms DPI awerness with win32 native function call for Windows Vista and newer.
Function call is done prior to form init in BF1SimpleFPSTweaks/ApplicationEvents.vb

Inspired by: CESARSOUZA. (2015). http://crsouza.com/2015/04/13/how-to-fix-blurry-windows-forms-windows-in-high-dpi-settings/
